### PR TITLE
fix: endless dropdown

### DIFF
--- a/src/cogs/helpers/actions.py
+++ b/src/cogs/helpers/actions.py
@@ -161,7 +161,11 @@ class CreateTicket(BaseActions):
         if self.ticket_type == "help":
             helper = CreateTicketHelper(
                 self.ticket_channel, self.bot, self.ticket_type, self._args[0], *self._args[1], **self._args[2])
-            ch_authors = await helper.challenge_selection()
+            try:
+                ch_authors = await helper.challenge_selection()
+            except exceptions.ChallengeTimeoutError:
+                raise exceptions.ChallengeTimeoutError
+
             ch_authors = set(filter(lambda v: v is not None, ch_authors))
             if len(ch_authors) == 0:
                 author_mentions = ''

--- a/src/cogs/helpers/views/command_views.py
+++ b/src/cogs/helpers/views/command_views.py
@@ -17,7 +17,7 @@ class CreateHelpButton(discord.ui.Button['TicketView']):  # add emoji
                                              interaction.guild, interaction.user, interaction.channel)
         try:
             await create_ticket.main()
-        except (exceptions.MaxUserTicketError, exceptions.MaxChannelTicketError, discord.errors.NotFound):
+        except (exceptions.MaxUserTicketError, exceptions.MaxChannelTicketError, exceptions.ChallengeTimeoutError, discord.errors.NotFound):
             pass
 
 class TicketView(discord.ui.View):

--- a/src/utils/background.py
+++ b/src/utils/background.py
@@ -84,7 +84,7 @@ class AutoClose(commands.Cog):
 
         if check == 1:
             close = actions.CloseTicket(guild, bot, channel, bot=True)
-            await close.main(before_message="This ticket was automatically closed due to inactivity.")
+            await close.main(before_message="This ticket was automatically closed due to no response.")
             db.update_check("0", channel.id)
 
         elif check == 0:

--- a/src/utils/background.py
+++ b/src/utils/background.py
@@ -83,8 +83,8 @@ class AutoClose(commands.Cog):
         log.info(f"check: {check}- {channel}")
 
         if check == 1:
-            close = actions.CloseTicket(guild, bot, channel, background=True)
-            await close.main(inactivity=True)
+            close = actions.CloseTicket(guild, bot, channel, bot=True)
+            await close.main(before_message="This ticket was automatically closed due to inactivity.")
             db.update_check("0", channel.id)
 
         elif check == 0:

--- a/src/utils/exceptions.py
+++ b/src/utils/exceptions.py
@@ -4,12 +4,11 @@ class MaxChannelTicketError(Exception):
 class MaxUserTicketError(Exception):
     """Raised when the max number of tickets has been reached per user"""
 
-class NoChallengeSelected(Exception):
+class ChallengeTimeoutError(Exception):
     """Raised when no challenge is selected"""
 
 class ChallengeDoesNotExist(Exception):
     """Raised when challenges solved by helpers don't exist"""
-
 
 class HelperSyncError(Exception):
     """Raised when a helper is missing"""


### PR DESCRIPTION
Currently, if a user creates a help ticket and does not choose a challenge, the dropdown will repeatedly send with no closing condition. This PR aims to fix that by having a limit of three sends, with a ping each time. If the user does not choose a challenge, the ticket is automatically closed.